### PR TITLE
Phoenix performance

### DIFF
--- a/frameworks/Elixir/phoenix/config/prod.exs
+++ b/frameworks/Elixir/phoenix/config/prod.exs
@@ -14,7 +14,7 @@ config :hello, Hello.Repo,
   password: "benchmarkdbpass",
   database: "hello_world",
   hostname: "tfb-database",
-  pool_size: 14
+  pool_size: 35
 
 config :logger,
   compile_time_purge_matching: [


### PR DESCRIPTION
The previous connection count was too low. This was verified in the
most recent benchmark results, as explained in a comment here:
https://github.com/TechEmpower/FrameworkBenchmarks/pull/5153#issuecomment-578472870

Unfortunately, the new value is just a guess, but it should provide
better results across the board, as we will be able to do exploit
I/O parallelism in a single thread once all cores are busy.