### PR TITLE
Phoenix performance: remove Repo.checkout

### DIFF
--- a/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
+++ b/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
@@ -53,12 +53,10 @@ defmodule Hello.PageController do
       params["queries"]
       |> query_range()
       |> parallel(fn _ ->
-          Repo.checkout(fn ->
-            World
-            |> Repo.get(:rand.uniform(10000))
-            |> Ecto.Changeset.change(randomnumber: :rand.uniform(10000))
-            |> Repo.update!()
-          end)
+          World
+          |> Repo.get(:rand.uniform(10000))
+          |> Ecto.Changeset.change(randomnumber: :rand.uniform(10000))
+          |> Repo.update!()
         end)
       |> Jason.encode_to_iodata!()
 


### PR DESCRIPTION
While Repo.checkout reduces the time in checking out
the connection, it increases the time that the connection
is checked out, which can impact performance, especially
on a low count pool size.
